### PR TITLE
Refactor auth login and clean up unused code

### DIFF
--- a/BE-AUTH/src/main/java/com/example/msaauth/controller/AuthController.java
+++ b/BE-AUTH/src/main/java/com/example/msaauth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.example.msaauth.controller;
 
+import com.example.msaauth.dto.LoginDto;
 import com.example.msaauth.dto.MemberRequestDto;
 import com.example.msaauth.dto.MemberResponseDto;
 import com.example.msaauth.dto.TokenDto;
@@ -9,13 +10,10 @@ import com.example.msaauth.exception.DuplicateEmailException;
 import com.example.msaauth.repository.MemberRepository;
 import com.example.msaauth.service.AuthService;
 import com.example.msaauth.util.CookieUtil;
-import com.mysql.cj.log.Log;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
     private final MemberRepository memberRepository;
-    private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@Valid @RequestBody MemberRequestDto memberRequestDto) {
@@ -43,16 +40,15 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody MemberRequestDto memberRequestDto, HttpServletResponse response) {
+    public ResponseEntity<?> login(@RequestBody LoginDto loginDto, HttpServletResponse response) {
         try {
-            TokenResponseDto tokenResponse = authService.login(memberRequestDto);
+            TokenResponseDto tokenResponse = authService.login(loginDto);
 
             HttpHeaders headers = new HttpHeaders();
             headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.getAccessToken());
             CookieUtil.addRefreshTokenToCookie(response, tokenResponse.getRefreshToken());
 
-            // 사용자 이메일과 권한 정보 생성
-            Member member = memberRepository.findByEmail(memberRequestDto.getEmail())
+            Member member = memberRepository.findByEmail(loginDto.getEmail())
                     .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
             MemberResponseDto userResponse = MemberResponseDto.of(member);
 

--- a/BE-AUTH/src/main/java/com/example/msaauth/service/AuthService.java
+++ b/BE-AUTH/src/main/java/com/example/msaauth/service/AuthService.java
@@ -2,7 +2,6 @@ package com.example.msaauth.service;
 
 
 
-import com.example.msaauth.controller.AuthController;
 import com.example.msaauth.dto.*;
 import com.example.msaauth.entity.Member;
 import com.example.msaauth.entity.RefreshToken;
@@ -11,14 +10,11 @@ import com.example.msaauth.jwt.TokenProvider;
 import com.example.msaauth.repository.MemberRepository;
 import com.example.msaauth.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +28,6 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
-    private static final Logger logger = LoggerFactory.getLogger(AuthService.class);
     @Transactional
     public MemberResponseDto signup(MemberRequestDto memberRequestDto) {
         if (memberRepository.existsByEmail(memberRequestDto.getEmail())) {
@@ -47,10 +42,10 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenResponseDto login(MemberRequestDto memberRequestDto) {
+    public TokenResponseDto login(LoginDto loginDto) {
         try {
             UsernamePasswordAuthenticationToken authenticationToken =
-                    memberRequestDto.toAuthentication();
+                    new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
 
             Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
@@ -64,7 +59,6 @@ public class AuthService {
 
             refreshTokenRepository.save(refreshToken);
 
-            // 액세스 토큰과 리프레시 토큰 정보 반환
             return new TokenResponseDto(tokenDto.getAccessToken(), tokenDto.getRefreshToken());
         } catch (BadCredentialsException e) {
             throw new RuntimeException("이메일 또는 비밀번호가 일치하지 않습니다.");
@@ -97,30 +91,21 @@ public class AuthService {
         if (!tokenProvider.validateToken(refreshToken)) {
             throw new RuntimeException("Refresh Token이 유효하지 않습니다.");
         }
-        logger.info("서비스1");
-        // 2. Refresh Token에서 Member ID 가져오기
-        Authentication authentication = tokenProvider.getAuthenticationFromRefreshToken(refreshToken);
-        logger.info("서비스2");
 
-        // 3. 저장소에서 Member ID 를 기반으로 Refresh Token 값 가져옴
+        Authentication authentication = tokenProvider.getAuthenticationFromRefreshToken(refreshToken);
+
         RefreshToken refreshTokenEntity = refreshTokenRepository.findByKey(authentication.getName())
                 .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다."));
-        logger.info("서비스3");
 
-        // 4. Refresh Token 일치하는지 검사
         if (!refreshTokenEntity.getValue().equals(refreshToken)) {
             throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
         }
-        logger.info("서비스4");
 
-        // 5. 새로운 토큰 생성
         TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
 
-        // 6. 저장소 정보 업데이트
         RefreshToken newRefreshToken = refreshTokenEntity.updateValue(tokenDto.getRefreshToken());
         refreshTokenRepository.save(newRefreshToken);
 
-        // 토큰 발급
         return tokenDto;
     }
 }


### PR DESCRIPTION
## Summary
- use dedicated `LoginDto` for login endpoint
- remove unused imports and redundant logging
- streamline refresh token reissue logic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68971d6f490c8326b0cd1283e93b6aab