### PR TITLE
refactor kakao pay to use webclient

### DIFF
--- a/BE-MERCH/BE-MERCH-KAKAO/build.gradle
+++ b/BE-MERCH/BE-MERCH-KAKAO/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.security:spring-security-crypto:6.2.1'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-logging:3.2.2'

--- a/KAKAO_PAY_GUIDE.md
+++ b/KAKAO_PAY_GUIDE.md
@@ -1,0 +1,6 @@
+# Kakao Pay Integration Guidelines
+
+- Use `WebClient` from Spring WebFlux for communicating with Kakao Pay APIs.
+- Set required headers such as `Authorization` and `Content-Type` using `headers` on the request.
+- Prefer non-blocking flows; `block()` may be used when synchronous behavior is acceptable.
+- Avoid using `RestTemplate` for new development.


### PR DESCRIPTION
## Summary
- replace RestTemplate with WebClient in merchandise KakaoPayService
- add WebFlux dependency and document WebClient usage

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689721a946f083269da1cd692b8005ef