### PR TITLE
feat: publish and consume payment events via Kafka

### DIFF
--- a/BE-MERCH/BE-MERCH-KAKAO/build.gradle
+++ b/BE-MERCH/BE-MERCH-KAKAO/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-logging:3.2.2'
     implementation 'mysql:mysql-connector-java:8.0.26'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     //jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/BE-MERCH/BE-MERCH-KAKAO/src/main/java/com/example/bemerch/kafka/KafkaConfig.java
+++ b/BE-MERCH/BE-MERCH-KAKAO/src/main/java/com/example/bemerch/kafka/KafkaConfig.java
@@ -1,0 +1,55 @@
+package com.example.bemerch.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaConfig {
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "merch-service");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/BE-MERCH/BE-MERCH-KAKAO/src/main/java/com/example/bemerch/kafka/PaymentEventConsumer.java
+++ b/BE-MERCH/BE-MERCH-KAKAO/src/main/java/com/example/bemerch/kafka/PaymentEventConsumer.java
@@ -1,0 +1,14 @@
+package com.example.bemerch.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class PaymentEventConsumer {
+    @KafkaListener(topics = {"payment-success", "payment-refund"}, groupId = "merch-service")
+    public void listen(String message) {
+        log.info("Received payment event: {}", message);
+    }
+}

--- a/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/build.gradle
+++ b/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-logging:3.2.2'
     implementation 'mysql:mysql-connector-java:8.0.26'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     //jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/src/main/java/com/example/bemsaseat/SeatController.java
+++ b/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/src/main/java/com/example/bemsaseat/SeatController.java
@@ -120,7 +120,7 @@ public class SeatController {
             List<MinimalSeatDTO> minimalSeatDTOList = purchaseResponse.getBookedSeats();
             String jwtToken = purchaseResponse.getJwtToken();
 
-            seatService.sendPurchaseRequest(minimalSeatDTOList, jwtToken);
+            seatService.sendPurchaseRequest(minimalSeatDTOList);
 
             log.info("Sending list of MinimalSeatDTO as response: {}", minimalSeatDTOList);
 

--- a/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/src/main/java/com/example/bemsaseat/kafka/KafkaConfig.java
+++ b/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/src/main/java/com/example/bemsaseat/kafka/KafkaConfig.java
@@ -1,0 +1,55 @@
+package com.example.bemsaseat.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaConfig {
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "seat-service");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/src/main/java/com/example/bemsaseat/kafka/PaymentEventConsumer.java
+++ b/BE-SEAT/BE-SEAT-YES-NUMBER-YES-KAKAO/src/main/java/com/example/bemsaseat/kafka/PaymentEventConsumer.java
@@ -1,0 +1,28 @@
+package com.example.bemsaseat.kafka;
+
+import com.example.bemsaseat.seat.dto.MinimalSeatDTO;
+import com.example.bemsaseat.seat.service.SeatService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventConsumer {
+    private final SeatService seatService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @KafkaListener(topics = "payment-refund", groupId = "seat-service")
+    public void handleRefund(String message) throws Exception {
+        List<MinimalSeatDTO> seatDTOs = objectMapper.readValue(message, new TypeReference<List<MinimalSeatDTO>>() {});
+        for (MinimalSeatDTO dto : seatDTOs) {
+            log.info("Processing refund for seat {}", dto);
+            seatService.cancelSeat(dto);
+        }
+    }
+}

--- a/BE-TICKET/BE-TICKET-KAKAO/build.gradle
+++ b/BE-TICKET/BE-TICKET-KAKAO/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-logging:3.2.2'
     implementation 'mysql:mysql-connector-java:8.0.26'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     //jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/BE-TICKET/BE-TICKET-KAKAO/src/main/java/com/example/bemsaticket/kafka/KafkaConfig.java
+++ b/BE-TICKET/BE-TICKET-KAKAO/src/main/java/com/example/bemsaticket/kafka/KafkaConfig.java
@@ -1,0 +1,55 @@
+package com.example.bemsaticket.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaConfig {
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "ticket-service");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/BE-TICKET/BE-TICKET-KAKAO/src/main/java/com/example/bemsaticket/kafka/PaymentEventConsumer.java
+++ b/BE-TICKET/BE-TICKET-KAKAO/src/main/java/com/example/bemsaticket/kafka/PaymentEventConsumer.java
@@ -1,0 +1,26 @@
+package com.example.bemsaticket.kafka;
+
+import com.example.bemsaticket.ticket.dto.MinimalSeatDTO;
+import com.example.bemsaticket.ticket.service.TicketService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventConsumer {
+    private final TicketService ticketService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @KafkaListener(topics = "payment-success", groupId = "ticket-service")
+    public void handlePaymentSuccess(String message) throws Exception {
+        List<MinimalSeatDTO> seatDTOs = objectMapper.readValue(message, new TypeReference<List<MinimalSeatDTO>>() {});
+        log.info("Consuming payment-success event for {} seats", seatDTOs.size());
+        ticketService.saveTicketsFromEvent(seatDTOs);
+    }
+}


### PR DESCRIPTION
## Summary
- send `payment-success` events from seat service after successful purchases
- consume payment events in ticket and merch services with Kafka
- emit `payment-refund` events from ticket service on cancellation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689745df2adc8326ae2975bd911ef574